### PR TITLE
Updated ca.fido

### DIFF
--- a/sms_mms_gateways.txt
+++ b/sms_mms_gateways.txt
@@ -124,7 +124,7 @@
 		"ca" : {
 			"aliant" : ["Aliant", "{number}@chat.wirefree.ca"],
 			"bellmobility" : ["Bell Mobility & Solo Mobile", "{number}@txt.bell.ca", "{number}@txt.bellmobility.ca"],
-			"fido" : ["Fido", "{number}@sms.fido.ca"],
+			"fido" : ["Fido", "{number}@fido.ca"],
 			"koodo" : ["Koodo Mobile", "{number}@msg.telus.com"],
 			"lynx_mobility" : ["Lynx Mobility", "{number}@sms.lynxmobility.com"],
 			"manitoba_telecom" : ["Manitoba Telecom/MTS Mobility", "{number}@text.mtsmobility.com"],


### PR DESCRIPTION
According to fido's documentation (http://www.fido.ca/consumer/content/email-to-text), the correct address is "myfidonumber@fido.ca".