### PR TITLE
Remove Ting

### DIFF
--- a/sms_mms_gateways.txt
+++ b/sms_mms_gateways.txt
@@ -1,7 +1,7 @@
 {
 	"info" : "JSON array containing e-mail to SMS and MMS mappings constructed from the best available sources and DNS validations.  (C) 2018 CubicleSoft.  All Rights Reserved.",
 	"license" : "MIT or LGPL.  See http://github.com/cubiclesoft/email_sms_mms_gateways for details.",
-	"lastupdated" : "2018-11-08",
+	"lastupdated" : "2021-06-29",
 	"countries" : {
 		"us" : "United States",
 		"ca" : "Canada",
@@ -110,7 +110,6 @@
 			"syringa" : ["Syringa Wireless", "{number}@rinasms.com"],
 			"t_mobile" : ["T-Mobile", "{number}@tmomail.net"],
 			"teleflip" : ["Teleflip", "{number}@teleflip.com"],
-			"ting" : ["Ting", "{number}@message.ting.com"],
 			"tracfone" : ["Tracfone", "{number}@mmst5.tracfone.com"],
 			"telus_mobility" : ["Telus Mobility", "{number}@msg.telus.com"],
 			"unicel" : ["Unicel", "{number}@utext.com"],


### PR DESCRIPTION
Ting does not support an SMS gateway. See the "IMPORTANT" note under number 7 on the [Ting support page](https://help.ting.com/hc/en-us/articles/205421938-Text-Messaging#:~:text=On%20CDMA%20devices%2C%20use%20the,text%20message%20to%20your%20device). I've also pasted the text below:

> IMPORTANT: Our network partners do not provide service level guarantees for email-to-SMS messaging delivery. As a result, the email-to-text functionality is unsupported on the Ting network. This service may not work correctly, or at all, with certain devices and/or conditions